### PR TITLE
Add user setting and account pages

### DIFF
--- a/zlb-p/api/order.js
+++ b/zlb-p/api/order.js
@@ -1,0 +1,3 @@
+export const listOrders = () => Promise.resolve([])
+export const getOrderDetail = () => Promise.resolve({})
+export const submitRate = () => Promise.resolve({})

--- a/zlb-p/components/OrderRate.vue
+++ b/zlb-p/components/OrderRate.vue
@@ -1,0 +1,67 @@
+<template>
+  <u-popup :show="show" mode="center" :round="16" @close="close">
+    <view class="popup">
+      <u-icon name="close" class="close" size="20" @click="close" />
+      <view class="title">综合评分</view>
+      <u-rate v-model="score" active-color="#FFC107" />
+      <view class="title">综合评价</view>
+      <u--textarea v-model="content" placeholder="请输入内容" height="200" border="1" border-color="#EBEEF5" radius="8" />
+      <u-button type="primary" shape="circle" class="btn" @click="submit">确定</u-button>
+    </view>
+  </u-popup>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      show: false,
+      orderId: null,
+      score: 0,
+      content: '',
+    };
+  },
+  methods: {
+    open(id) {
+      this.orderId = id;
+      this.show = true;
+    },
+    close() {
+      this.show = false;
+      this.score = 0;
+      this.content = '';
+    },
+    submit() {
+      if (this.score <= 0) return uni.$u.toast('请评分');
+      this.$emit('submit', {
+        orderId: this.orderId,
+        score: this.score,
+        content: this.content,
+      });
+      this.close();
+    },
+  },
+};
+</script>
+
+<style scoped>
+.popup {
+  padding: 40rpx 20rpx 60rpx;
+  text-align: center;
+  position: relative;
+}
+.close {
+  position: absolute;
+  top: 20rpx;
+  right: 20rpx;
+}
+.title {
+  font-size: 26rpx;
+  font-weight: 600;
+  margin: 20rpx 0;
+}
+.btn {
+  width: 80%;
+  margin-top: 40rpx;
+}
+</style>

--- a/zlb-p/pages.json
+++ b/zlb-p/pages.json
@@ -37,14 +37,68 @@
 				"navigationBarTitleText": "个人中心"
 			}
 		}, {
-			"path": "pages/badges/badges",
-			"style": {
-				"navigationBarTitleText": "徽章列表"
-			}
-		}
+                "path": "pages/badges/badges",
+                        "style": {
+                                "navigationBarTitleText": "徽章列表"
+                        }
+                },
 
-	],
-	"tabBar": {
+                {
+                        "path": "pages/user/home/home",
+                        "style": {
+                                "navigationBarTitleText": ""
+                        }
+                },
+                {
+                        "path": "pages/user/search/search",
+                        "style": {
+                                "navigationBarTitleText": ""
+                        }
+                },
+                {
+                        "path": "pages/user/search/result",
+                        "style": {
+                                "navigationBarTitleText": ""
+                        }
+                },
+                {
+                        "path": "pages/order/index",
+                        "style": {
+                                "navigationBarTitleText": ""
+                        }
+                },
+                {
+                        "path": "pages/order/detail",
+                        "style": {
+                                "navigationBarTitleText": ""
+                        }
+                },
+                {
+                        "path": "pages/user/setting",
+                        "style": {
+                                "navigationBarTitleText": ""
+                        }
+                },
+                {
+                        "path": "pages/user/personal",
+                        "style": {
+                                "navigationBarTitleText": ""
+                        }
+                },
+                {
+                        "path": "pages/user/account",
+                        "style": {
+                                "navigationBarTitleText": ""
+                        }
+                },
+                {
+                        "path": "pages/user/payPwd",
+                        "style": {
+                                "navigationBarTitleText": ""
+                        }
+                }
+        ],
+        "tabBar": {
 		"color": "#999999",
 		"selectedColor": "#BB4FE1",
 		"borderStyle": "black",

--- a/zlb-p/pages/order/detail.vue
+++ b/zlb-p/pages/order/detail.vue
@@ -1,0 +1,134 @@
+<template>
+  <view class="detail-page">
+    <view class="status" :class="order.status">{{ statusText(order.status) }}</view>
+    <view class="card">
+      <view class="header">
+        <image :src="order.cover" class="cover" mode="aspectFill" />
+        <view class="header-info">
+          <view class="name">{{ order.gym }}</view>
+          <view class="mode">{{ order.mode }}</view>
+        </view>
+      </view>
+      <view class="schedule">
+        <view v-for="(it,i) in order.orderItems" :key="i" class="row">
+          <text class="flex">{{ it.date }}</text>
+          <text class="flex">{{ it.field }}</text>
+          <text class="flex">{{ it.time }}</text>
+          <text class="money">{{ it.amount }}</text>
+        </view>
+        <view class="total">总计：{{ order.totalHours }}小时 {{ order.amount }}</view>
+      </view>
+      <view class="fee">
+        <view class="row"><text class="label">实付金额</text><text class="value strong">{{ order.payReal }}</text></view>
+        <view class="row"><text class="label">优惠金额</text><text class="value">{{ order.discount }}</text></view>
+        <view class="row"><text class="label">支付方式</text><text class="value">{{ order.payMethod }}</text></view>
+        <view class="row"><text class="label">下单时间</text><text class="value">{{ order.createTime }}</text></view>
+      </view>
+    </view>
+    <u-button v-if="order.canRate" type="primary" shape="circle" class="rate-btn" @click="openRate">去评价</u-button>
+    <OrderRate ref="rate" @submit="submitRate" />
+  </view>
+</template>
+
+<script>
+import OrderRate from '@/components/OrderRate.vue'
+export default {
+  components:{OrderRate},
+  data(){
+    return {
+      order:{
+        status:'done',
+        cover:'https://via.placeholder.com/120',
+        gym:'示例场馆',
+        mode:'在线预定',
+        orderItems:[{date:'2025-01-01',field:'A1',time:'08:00-09:00',amount:'￥50.00'}],
+        totalHours:1,
+        amount:'￥50.00',
+        payReal:'￥50.00',
+        discount:'￥0.00',
+        payMethod:'微信支付',
+        createTime:'2025-01-01 10:00',
+        canRate:true
+      }
+    }
+  },
+  methods:{
+    statusText(s){
+      const map={unused:'待使用',done:'已完成',refund:'已退款'}
+      return map[s]||''
+    },
+    openRate(){
+      this.$refs.rate.open(this.order.orderNo)
+    },
+    submitRate(data){
+      // TODO submit rating
+    }
+  }
+}
+</script>
+
+<style scoped>
+.detail-page{
+  background:#F5F5F5;
+  min-height:100vh;
+  padding:24rpx;
+}
+.status{
+  font-size:28rpx;
+  font-weight:600;
+  margin-bottom:20rpx;
+}
+.status.unused{color:#FF5722;}
+.status.done{color:#909399;}
+.status.refund{color:#909399;}
+.card{
+  background:#FFFFFF;
+  border-radius:8px;
+  box-shadow:0 2rpx 8rpx rgba(0,0,0,0.05);
+  padding:24rpx;
+}
+.header{
+  display:flex;
+}
+.cover{
+  width:120rpx;
+  height:120rpx;
+  border-radius:8px;
+  margin-right:20rpx;
+}
+.header-info{
+  flex:1;
+}
+.name{
+  font-size:28rpx;
+  font-weight:600;
+  color:#202020;
+}
+.mode{
+  font-size:22rpx;
+  color:#606266;
+  margin-top:4rpx;
+}
+.schedule{
+  background:#F7F8FA;
+  border-radius:8px;
+  padding:24rpx;
+  margin-top:20rpx;
+}
+.row{
+  display:flex;
+  font-size:24rpx;
+  line-height:36rpx;
+}
+.row + .row{border-top:1rpx solid #EBEEF5;}
+.flex{flex:1;}
+.money{width:140rpx;text-align:right;font-weight:600;}
+.total{margin-top:10rpx;text-align:right;font-size:24rpx;font-weight:600;}
+.fee{
+  margin-top:20rpx;
+  font-size:24rpx;
+}
+.fee .row{display:flex;justify-content:space-between;line-height:36rpx;}
+.fee .strong{font-weight:600;}
+.rate-btn{width:80%;margin:40rpx auto;}
+</style>

--- a/zlb-p/pages/order/index.vue
+++ b/zlb-p/pages/order/index.vue
@@ -1,0 +1,173 @@
+<template>
+  <view class="order-page">
+    <u-tabs :list="tabList" :current="current" line-color="#1FCF76" active-color="#1FCF76" inactive-color="#606266" line-height="4" line-width="60" @click="changeTab" />
+    <scroll-view class="list" scroll-y refresher-enabled :refresher-triggered="refreshing" @refresherrefresh="onRefresh" @scrolltolower="onLoadMore">
+      <view v-for="(item,index) in orders" :key="index" class="card" @click="goDetail(item)">
+        <view class="card-header">
+          <text class="no">订单编号：{{ item.orderNo }}</text>
+          <text class="status" :class="item.status">{{ statusText(item.status) }}</text>
+        </view>
+        <view class="card-content">
+          <image :src="item.cover" class="cover" mode="aspectFill" />
+          <view class="info">
+            <view class="name">{{ item.gym }}</view>
+            <view class="mode">{{ item.mode }}</view>
+            <view class="price"><text>实付款</text><text class="amount">{{ item.amount }}</text></view>
+          </view>
+        </view>
+        <view class="card-footer">
+          <u-button v-if="item.canRate" type="primary" plain shape="circle" size="mini" @click.stop="openRate(item)">评价</u-button>
+        </view>
+      </view>
+      <u-empty v-if="!orders.length && loadStatus!=='loading'" text="暂无数据" mode="list" />
+      <u-loadmore :status="loadStatus" />
+    </scroll-view>
+    <OrderRate ref="rate" @submit="submitRate" />
+  </view>
+</template>
+
+<script>
+import OrderRate from '@/components/OrderRate.vue'
+export default {
+  components: { OrderRate },
+  data() {
+    return {
+      tabList: [
+        { name: '全部', value: 'all' },
+        { name: '待使用', value: 'unused' },
+        { name: '已完成', value: 'done' },
+        { name: '已退款', value: 'refund' }
+      ],
+      current: 0,
+      status: 'all',
+      orders: [],
+      page: 1,
+      pageSize: 10,
+      loadStatus: 'loadmore',
+      refreshing: false
+    }
+  },
+  onLoad() {
+    this.fetchList(true)
+  },
+  methods: {
+    statusText(s){
+      const map={unused:'待使用',done:'已完成',refund:'已退款'}
+      return map[s]||'全部'
+    },
+    changeTab(index){
+      this.current=index
+      this.status=this.tabList[index].value
+      this.fetchList(true)
+    },
+    onRefresh(){
+      this.refreshing=true
+      this.fetchList(true)
+    },
+    onLoadMore(){
+      this.fetchList()
+    },
+    fetchList(reset=false){
+      if(reset){
+        this.page=1
+        this.orders=[]
+      }
+      this.loadStatus='loading'
+      setTimeout(()=>{
+        const list=Array.from({length:this.pageSize},(_,i)=>{
+          const idx=(this.page-1)*this.pageSize+i+1
+          return {
+            orderNo: '20250'+idx,
+            status: this.status==='all' ? ['unused','done','refund'][i%3] : this.status,
+            cover: 'https://via.placeholder.com/120',
+            gym: '示例场馆'+idx,
+            mode: '在线预定',
+            amount: '￥99.00',
+            canRate: this.status==='done'
+          }
+        })
+        this.orders=this.orders.concat(list)
+        this.page++
+        this.loadStatus=this.page>2?'nomore':'loadmore'
+        this.refreshing=false
+      },500)
+    },
+    goDetail(item){
+      uni.navigateTo({url:'/pages/order/detail'})
+    },
+    openRate(item){
+      this.$refs.rate.open(item.orderNo)
+    },
+    submitRate(data){
+      // TODO: submit rating
+    }
+  }
+}
+</script>
+
+<style scoped>
+.order-page{
+  background:#F5F5F5;
+  min-height:100vh;
+  padding:24rpx;
+}
+.list{
+  height:calc(100vh - 80rpx);
+  margin-top:20rpx;
+}
+.card{
+  background:#FFFFFF;
+  border-radius:8px;
+  box-shadow:0 2rpx 8rpx rgba(0,0,0,0.05);
+  padding:24rpx;
+  margin-bottom:20rpx;
+}
+.card-header{
+  display:flex;
+  justify-content:space-between;
+  font-size:22rpx;
+  color:#909399;
+}
+.status.unused{color:#FF5722;}
+.status.done{color:#909399;}
+.status.refund{color:#909399;}
+.card-content{
+  display:flex;
+  margin-top:20rpx;
+}
+.cover{
+  width:120rpx;
+  height:120rpx;
+  border-radius:8px;
+  margin-right:20rpx;
+}
+.info{flex:1;position:relative;}
+.name{
+  font-size:28rpx;
+  font-weight:600;
+  color:#202020;
+  line-height:36rpx;
+}
+.mode{
+  font-size:22rpx;
+  color:#606266;
+  margin-top:4rpx;
+}
+.price{
+  position:absolute;
+  right:0;
+  bottom:0;
+  font-size:22rpx;
+  color:#202020;
+}
+.amount{
+  font-weight:600;
+  font-size:26rpx;
+  margin-left:8rpx;
+}
+.card-footer{
+  display:flex;
+  justify-content:flex-end;
+  margin-top:20rpx;
+}
+</style>

--- a/zlb-p/pages/user/account.vue
+++ b/zlb-p/pages/user/account.vue
@@ -1,0 +1,93 @@
+<template>
+  <view class="page">
+    <view class="gap"></view>
+    <u-cell-group>
+      <u-cell title="账号" :value="account" :border="false" />
+      <u-cell title="绑定微信号" :value="wechat" />
+      <u-cell title="旧登录密码" :border="false">
+        <template #value>
+          <u-input v-model="form.oldPwd" type="password" placeholder="必填" border="none" />
+        </template>
+      </u-cell>
+      <u-cell title="新登录密码">
+        <template #value>
+          <u-input v-model="form.newPwd" type="password" placeholder="必填" border="none" />
+        </template>
+      </u-cell>
+      <u-cell title="确定登录密码">
+        <template #value>
+          <u-input v-model="form.confirmPwd" type="password" placeholder="必填" border="none" />
+        </template>
+      </u-cell>
+    </u-cell-group>
+    <view class="tip">密码必须是 8-16 位英文、数字、字符组合</view>
+    <view class="footer">
+      <u-link :href="''" @click="forgetPwd" text="忘记密码？" :color="themeColor" />
+    </view>
+    <view class="btn">
+      <u-button type="primary" shape="circle" @click="save">保存</u-button>
+    </view>
+  </view>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      themeColor: '#1FCF76',
+      account: 'user@example.com',
+      wechat: '未绑定',
+      form: {
+        oldPwd: '',
+        newPwd: '',
+        confirmPwd: ''
+      }
+    }
+  },
+  methods: {
+    forgetPwd() {
+      // TODO: 忘记密码逻辑
+    },
+    save() {
+      if (!this.form.oldPwd || !this.form.newPwd || !this.form.confirmPwd) {
+        uni.showToast({ title: '请填写完整', icon: 'none' })
+        return
+      }
+      if (this.form.newPwd !== this.form.confirmPwd) {
+        uni.showToast({ title: '两次密码不一致', icon: 'none' })
+        return
+      }
+      const reg = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,16}$/
+      if (!reg.test(this.form.newPwd)) {
+        uni.showToast({ title: '密码格式不正确', icon: 'none' })
+        return
+      }
+      // TODO: 提交接口
+      uni.showToast({ title: '已保存', icon: 'none' })
+    }
+  }
+}
+</script>
+
+<style scoped>
+.page {
+  background: #F5F5F5;
+  min-height: 100vh;
+  padding: 24rpx;
+}
+.gap {
+  height: 20rpx;
+}
+.tip {
+  font-size: 22rpx;
+  color: #909399;
+  margin: 20rpx 0;
+}
+.footer {
+  text-align: right;
+  margin-bottom: 20rpx;
+}
+.btn {
+  text-align: center;
+}
+</style>

--- a/zlb-p/pages/user/home/home.vue
+++ b/zlb-p/pages/user/home/home.vue
@@ -1,0 +1,212 @@
+<template>
+        <view class="home-page">
+                <u-navbar placeholder :border-bottom="false">
+                        <view slot="left" class="city" @click="changeCity">
+                                <text>{{ city }}</text>
+                                <u-icon name="arrow-down" size="14" color="#202020" style="margin-left:4rpx" />
+                        </view>
+                        <view slot="center" class="search" @click="goSearch">
+                                <u-search placeholder="输入球馆名称" disabled></u-search>
+                        </view>
+                        <view slot="right" class="nav-icons">
+                                <u-icon name="calendar" size="22" :color="themeColor" @click="goBooking" />
+                                <u-icon name="map" size="22" color="#606266" style="margin-left:16rpx" @click="locate" />
+                        </view>
+                </u-navbar>
+
+                <view class="banner">
+                        <u-swiper :list="banners" height="200" radius="8" />
+                </view>
+
+                <view class="tabs">
+                        <u-tabs :list="tabList" :current="currentTab" line-width="40" line-color="#1FCF76" active-color="#1FCF76" inactive-color="#606266" @click="onTabChange" />
+                </view>
+
+                <view class="filter-row">
+                        <u-row>
+                                <u-col span="4" class="filter-item" @click="openDistance">
+                                        <text :class="sort==='distance' ? 'active' : ''">距离 ↕︎</text>
+                                </u-col>
+                                <u-col span="4" class="filter-item" @click="openRating">
+                                        <text :class="sort==='rating' ? 'active' : ''">评分 ↕︎</text>
+                                </u-col>
+                                <u-col span="4" class="filter-item filter-icon" @click="openFilter">
+                                        <u-icon name="list" size="18" color="#606266" />
+                                        <text>筛选</text>
+                                </u-col>
+                        </u-row>
+                </view>
+
+                <view class="venue-list">
+                        <view v-for="(v,i) in venues" :key="i" class="venue-card" @click="goDetail(v)">
+                                <image :src="v.image" class="venue-img" mode="aspectFill" />
+                                <view class="venue-info">
+                                        <view class="title">{{ v.title }}</view>
+                                        <view class="rating">{{ v.rating }}</view>
+                                        <view class="tags">
+                                                <u-tag v-for="(t,index) in v.tags" :key="index" :text="t" type="info" size="mini" plain :color="themeColor" :border-color="themeColor" custom-class="tag" />
+                                        </view>
+                                        <view class="distance">{{ v.distance }}</view>
+                                </view>
+                        </view>
+                        <u-empty v-if="venues.length===0" text="暂无数据" mode="list" />
+                        <u-loadmore :status="loadStatus" />
+                </view>
+
+                <u-action-sheet :show="showDistanceSheet" :actions="distanceOptions" @select="onDistanceSelect" @close="showDistanceSheet=false" />
+                <u-action-sheet :show="showRatingSheet" :actions="ratingOptions" @select="onRatingSelect" @close="showRatingSheet=false" />
+                <u-drawer :show="filterDrawer" mode="right" @close="filterDrawer=false">
+                        <view style="padding:24rpx">筛选内容</view>
+                </u-drawer>
+        </view>
+</template>
+
+<script>
+export default {
+        data() {
+                return {
+                        themeColor: '#1FCF76',
+                        city: '上海',
+                        banners: [
+                                'https://via.placeholder.com/750x200'
+                        ],
+                        tabList: [
+                                { name: '羽毛球' },
+                                { name: '排球' },
+                                { name: '篮球' }
+                        ],
+                        currentTab: 0,
+                        sort: '',
+                        venues: [],
+                        loadStatus: 'loadmore',
+                        showDistanceSheet: false,
+                        showRatingSheet: false,
+                        distanceOptions: [ {name:'500米内'}, {name:'1公里内'}, {name:'5公里内'} ],
+                        ratingOptions: [ {name:'评分从高到低'}, {name:'评分从低到高'} ],
+                        filterDrawer: false
+                }
+        },
+        methods: {
+                changeCity() {
+                        // TODO: 打开城市选择弹窗
+                },
+                goSearch() {
+                        // TODO: 跳转搜索页
+                },
+                goBooking() {
+                        // TODO: 跳转预约页面
+                },
+                locate() {
+                        // TODO: 定位
+                },
+                openDistance() {
+                        this.showDistanceSheet = true
+                },
+                onDistanceSelect(e) {
+                        this.sort = 'distance'
+                        this.showDistanceSheet = false
+                },
+                openRating() {
+                        this.showRatingSheet = true
+                },
+                onRatingSelect(e) {
+                        this.sort = 'rating'
+                        this.showRatingSheet = false
+                },
+                openFilter() {
+                        this.filterDrawer = true
+                },
+                goDetail(v) {
+                        // TODO: 跳转详情
+                },
+                onTabChange(index) {
+                        this.currentTab = index
+                }
+        }
+}
+</script>
+
+<style scoped>
+.home-page {
+        background: #F5F5F5;
+        min-height: 100vh;
+        padding: 24rpx;
+}
+.search {
+        flex: 1;
+}
+.banner {
+        margin-top: 20rpx;
+        border-radius: 8px;
+        overflow: hidden;
+}
+.tabs {
+        margin-top: 20rpx;
+}
+.filter-row {
+        margin-top: 20rpx;
+}
+.filter-item {
+        text-align: center;
+        font-size: 28rpx;
+        color: #606266;
+}
+.filter-item.active,
+.filter-item text.active {
+        color: #1FCF76;
+}
+.filter-icon {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+}
+.filter-icon text {
+        margin-left: 8rpx;
+}
+.venue-card {
+        background: #FFFFFF;
+        border-radius: 8px;
+        box-shadow: 0 2rpx 8rpx rgba(0, 0, 0, 0.05);
+        padding: 24rpx;
+        display: flex;
+        margin-top: 20rpx;
+}
+.venue-img {
+        width: 140rpx;
+        height: 140rpx;
+        border-radius: 8px;
+        margin-right: 20rpx;
+}
+.venue-info {
+        flex: 1;
+        position: relative;
+}
+.title {
+        font-size: 30rpx;
+        font-weight: 600;
+        color: #202020;
+        margin-right: 80rpx;
+}
+.rating {
+        position: absolute;
+        right: 0;
+        top: 0;
+        color: #1FCF76;
+        font-size: 30rpx;
+}
+.tags {
+        margin-top: 40rpx;
+        display: flex;
+        flex-wrap: wrap;
+}
+.tag {
+        margin-right: 10rpx;
+        margin-bottom: 10rpx;
+        padding: 0 10rpx;
+}
+.distance {
+        color: #909399;
+        font-size: 22rpx;
+        margin-top: 10rpx;
+}
+</style>

--- a/zlb-p/pages/user/payPwd.vue
+++ b/zlb-p/pages/user/payPwd.vue
@@ -1,0 +1,57 @@
+<template>
+  <view class="page">
+    <view class="title">请设置支付密码</view>
+    <u-code-input v-model="pwd" mode="box" maxlength="6" @finish="onComplete" />
+    <u-number-keyboard :show="true" @change="onKey" :custom-style="keyboardStyle">
+      <template #delete-icon>
+        <u-icon name="close" size="24" />
+      </template>
+    </u-number-keyboard>
+  </view>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      themeColor: '#1FCF76',
+      pwd: '',
+      keyboardStyle: 'position:fixed;bottom:0;left:0;width:100%;'
+    }
+  },
+  methods: {
+    onKey(val) {
+      if (val === 'delete') {
+        this.pwd = this.pwd.slice(0, -1)
+      } else {
+        if (this.pwd.length < 6) this.pwd += val
+        if (this.pwd.length === 6) this.onComplete(this.pwd)
+      }
+    },
+    onComplete(val) {
+      // TODO: setPayPwd
+      uni.showToast({ title: '设置成功', icon: 'none' })
+      setTimeout(() => {
+        uni.navigateBack()
+      }, 500)
+    }
+  }
+}
+</script>
+
+<style scoped>
+.page {
+  background: #F5F5F5;
+  min-height: 100vh;
+  padding: 24rpx;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.title {
+  font-size: 30rpx;
+  font-weight: 600;
+  margin-top: 60rpx;
+  margin-bottom: 40rpx;
+}
+</style>

--- a/zlb-p/pages/user/personal.vue
+++ b/zlb-p/pages/user/personal.vue
@@ -1,0 +1,83 @@
+<template>
+  <view class="page">
+    <view class="gap"></view>
+    <u-cell-group>
+      <u-cell title="头像" is-link :border="false" right-icon-style="color:#C0C4CC" @click="chooseAvatar">
+        <template #value>
+          <image :src="avatar" class="avatar" />
+        </template>
+      </u-cell>
+    </u-cell-group>
+    <view class="gap"></view>
+    <u-cell-group>
+      <u-cell title="昵称" :border="false">
+        <template #value>
+          <u-input v-model="form.nickname" placeholder="请输入" border="none" />
+        </template>
+      </u-cell>
+      <u-cell title="性别" is-link :value="form.gender" right-icon-style="color:#C0C4CC" @click="showGender=true" />
+      <u-cell title="水平" is-link :value="form.level" right-icon-style="color:#C0C4CC" @click="showLevel=true" />
+    </u-cell-group>
+    <view class="save-btn">
+      <u-button type="primary" shape="circle" @click="save">保存</u-button>
+    </view>
+    <u-picker :show="showGender" :columns="[genders]" @confirm="onGenderConfirm" @cancel="showGender=false" />
+    <u-picker :show="showLevel" :columns="[levels]" @confirm="onLevelConfirm" @cancel="showLevel=false" />
+  </view>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      avatar: 'https://via.placeholder.com/80',
+      form: {
+        nickname: '',
+        gender: '保密',
+        level: '初级'
+      },
+      genders: ['男', '女', '保密'],
+      levels: ['初级', '中级', '高级'],
+      showGender: false,
+      showLevel: false,
+    }
+  },
+  methods: {
+    chooseAvatar() {
+      uni.chooseImage({ count: 1, success: res => { this.avatar = res.tempFilePaths[0] } })
+    },
+    onGenderConfirm(e) {
+      this.form.gender = e.value[0]
+      this.showGender = false
+    },
+    onLevelConfirm(e) {
+      this.form.level = e.value[0]
+      this.showLevel = false
+    },
+    save() {
+      // TODO: 保存接口
+      uni.showToast({ title: '已保存', icon: 'none' })
+    }
+  }
+}
+</script>
+
+<style scoped>
+.page {
+  background: #F5F5F5;
+  min-height: 100vh;
+  padding: 24rpx;
+}
+.gap {
+  height: 20rpx;
+}
+.avatar {
+  width: 80rpx;
+  height: 80rpx;
+  border-radius: 50%;
+}
+.save-btn {
+  margin-top: 40rpx;
+  text-align: center;
+}
+</style>

--- a/zlb-p/pages/user/search/result.vue
+++ b/zlb-p/pages/user/search/result.vue
@@ -1,0 +1,178 @@
+<template>
+  <view class="result-page">
+    <u-search
+      v-model="keyword"
+      placeholder="输入球馆名称"
+      height="80"
+      :show-action="false"
+      @confirm="onConfirmSearch"
+    />
+
+    <scroll-view
+      class="list"
+      scroll-y
+      refresher-enabled
+      :refresher-triggered="isRefreshing"
+      @refresherrefresh="onRefresh"
+      @scrolltolower="onLoadMore"
+    >
+      <view v-for="(item, index) in gymList" :key="index" class="card" @click="goDetail(item)">
+        <image :src="item.image" class="img" mode="aspectFill" />
+        <view class="info">
+          <view class="top">
+            <text class="name">{{ item.name }}</text>
+            <text class="rating">{{ item.rating }}分</text>
+          </view>
+          <view class="tag-row">
+            <u-tag
+              v-for="(tag, i) in item.tags"
+              :key="i"
+              :text="tag"
+              plain
+              size="mini"
+              custom-class="tag"
+            />
+          </view>
+          <view class="distance">{{ item.distance }}</view>
+        </view>
+      </view>
+      <u-empty v-if="!gymList.length && loadStatus !== 'loading'" mode="list" text="暂无数据" />
+      <u-loadmore :status="loadStatus" />
+    </scroll-view>
+  </view>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      themeColor: '#1FCF76',
+      keyword: '',
+      gymList: [],
+      page: 1,
+      pageSize: 10,
+      loadStatus: 'loadmore',
+      isRefreshing: false,
+    };
+  },
+  onLoad(query) {
+    this.keyword = query.keyword || '';
+    this.fetchList(true);
+  },
+  methods: {
+    onConfirmSearch() {
+      if (!this.keyword) return;
+      // 更新历史
+      let history = uni.getStorageSync('historyList') || [];
+      history = history.filter(h => h !== this.keyword);
+      history.unshift(this.keyword);
+      if (history.length > 10) history.pop();
+      uni.setStorageSync('historyList', history);
+      this.fetchList(true);
+    },
+    onRefresh() {
+      this.isRefreshing = true;
+      this.fetchList(true);
+    },
+    onLoadMore() {
+      this.fetchList();
+    },
+    fetchList(reset = false) {
+      if (reset) {
+        this.page = 1;
+        this.gymList = [];
+      }
+      this.loadStatus = 'loading';
+
+      // 模拟异步请求
+      setTimeout(() => {
+        const list = Array.from({ length: this.pageSize }, (_, i) => {
+          const idx = (this.page - 1) * this.pageSize + i + 1;
+          return {
+            name: `${this.keyword}场馆${idx}`,
+            rating: '4.7',
+            image: 'https://via.placeholder.com/140',
+            tags: ['好停车', '可拉线', '有空调', '可洗澡'],
+            distance: `${(Math.random() * 10).toFixed(1)}km`,
+          };
+        });
+
+        this.gymList = this.gymList.concat(list);
+        this.page++;
+        this.loadStatus = this.page > 2 ? 'nomore' : 'loadmore';
+        this.isRefreshing = false;
+      }, 500);
+    },
+    goDetail(item) {
+      // TODO: 跳转到场馆详情页
+    },
+  },
+};
+</script>
+
+<style scoped>
+.result-page {
+  background: #f5f5f5;
+  min-height: 100vh;
+  padding: 24rpx;
+}
+.list {
+  margin-top: 20rpx;
+  height: calc(100vh - 104rpx);
+}
+.card {
+  display: flex;
+  background: #ffffff;
+  border-radius: 8px;
+  box-shadow: 0 2rpx 8rpx rgba(0, 0, 0, 0.05);
+  padding: 24rpx;
+  margin-bottom: 20rpx;
+}
+.img {
+  width: 140rpx;
+  height: 140rpx;
+  border-radius: 8px;
+  margin-right: 20rpx;
+}
+.info {
+  flex: 1;
+  position: relative;
+}
+.top {
+  display: flex;
+  justify-content: space-between;
+}
+.name {
+  font-size: 28rpx;
+  font-weight: 600;
+  color: #202020;
+  max-width: 360rpx;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.rating {
+  font-size: 26rpx;
+  color: #1FCF76;
+}
+.tag-row {
+  display: flex;
+  flex-wrap: wrap;
+  margin-top: 20rpx;
+}
+.tag {
+  margin-right: 10rpx;
+  margin-bottom: 10rpx;
+  font-size: 22rpx;
+  line-height: 32rpx;
+  color: #606266;
+  border-color: #C0C4CC;
+}
+.distance {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  color: #909399;
+  font-size: 22rpx;
+}
+</style>

--- a/zlb-p/pages/user/search/search.vue
+++ b/zlb-p/pages/user/search/search.vue
@@ -1,0 +1,141 @@
+<template>
+  <view class="search-page">
+    <u-search
+      v-model="keyword"
+      placeholder="输入球馆名称"
+      height="80"
+      :show-action="false"
+      @confirm="onConfirmSearch"
+    />
+
+    <view class="section">
+      <view class="title">我是会员</view>
+      <view class="tags">
+        <u-tag
+          v-for="(item, index) in memberGyms"
+          :key="index"
+          :text="item"
+          mode="light"
+          :color="themeColor"
+          :border-color="themeColor"
+          custom-class="tag"
+          @click="selectTag(item)"
+        />
+      </view>
+    </view>
+
+    <view class="section history" v-if="historyList.length">
+      <view class="history-header">
+        <view class="title">历史记录</view>
+        <u-icon
+          name="trash"
+          size="18"
+          class="clear"
+          @click="clearHistory"
+        />
+      </view>
+      <view class="tags">
+        <u-tag
+          v-for="(item, index) in historyList"
+          :key="index"
+          :text="item"
+          mode="light"
+          color="#C0C4CC"
+          border-color="#C0C4CC"
+          custom-class="tag"
+          @click="selectTag(item)"
+        />
+      </view>
+    </view>
+  </view>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      themeColor: '#1FCF76',
+      keyword: '',
+      memberGyms: ['羽协球馆', '体育中心', '市民广场'],
+      historyList: [],
+    };
+  },
+  onLoad() {
+    const list = uni.getStorageSync('historyList') || [];
+    this.historyList = list;
+  },
+  methods: {
+    onConfirmSearch() {
+      if (!this.keyword) return;
+      // 更新历史
+      const arr = this.historyList.filter(h => h !== this.keyword);
+      arr.unshift(this.keyword);
+      if (arr.length > 10) arr.pop();
+      this.historyList = arr;
+      uni.setStorageSync('historyList', arr);
+      this.gotoResult(this.keyword);
+    },
+    selectTag(name) {
+      this.keyword = name;
+      this.onConfirmSearch();
+    },
+    gotoResult(kw) {
+      uni.navigateTo({
+        url: `/pages/user/search/result?keyword=${kw}`,
+      });
+    },
+    clearHistory() {
+      uni.showModal({
+        title: '提示',
+        content: '确定清空历史记录吗？',
+        success: res => {
+          if (res.confirm) {
+            this.historyList = [];
+            uni.removeStorageSync('historyList');
+          }
+        },
+      });
+    },
+  },
+};
+</script>
+
+<style scoped>
+.search-page {
+  background: #f5f5f5;
+  min-height: 100vh;
+  padding: 24rpx;
+}
+.section {
+  margin-top: 20rpx;
+}
+.history {
+  margin-top: 40rpx;
+}
+.title {
+  font-size: 28rpx;
+  font-weight: 600;
+  color: #202020;
+  margin-bottom: 20rpx;
+}
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+}
+.tag {
+  margin-right: 20rpx;
+  margin-bottom: 20rpx;
+  padding: 0 20rpx;
+  height: 56rpx;
+  line-height: 56rpx;
+  font-size: 24rpx;
+}
+.history-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.clear {
+  color: #606266;
+}
+</style>

--- a/zlb-p/pages/user/setting.vue
+++ b/zlb-p/pages/user/setting.vue
@@ -1,0 +1,32 @@
+<template>
+  <view class="page">
+    <view class="gap"></view>
+    <u-cell-group>
+      <u-cell title="个人信息管理" is-link url="/pages/user/personal" right-icon-style="color:#C0C4CC" />
+      <u-cell title="账号密码管理" is-link url="/pages/user/account" right-icon-style="color:#C0C4CC" />
+      <u-cell title="支付密码管理" is-link url="/pages/user/payPwd" right-icon-style="color:#C0C4CC" />
+    </u-cell-group>
+    <view class="gap"></view>
+  </view>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      themeColor: '#1FCF76',
+    }
+  },
+}
+</script>
+
+<style scoped>
+.page {
+  background: #F5F5F5;
+  min-height: 100vh;
+  padding: 24rpx;
+}
+.gap {
+  height: 20rpx;
+}
+</style>

--- a/zlb-p/uni.scss
+++ b/zlb-p/uni.scss
@@ -75,3 +75,4 @@ $uni-color-subtitle: #555555; // 二级标题颜色
 $uni-font-size-subtitle:26px;
 $uni-color-paragraph: #3F536E; // 文章段落颜色
 $uni-font-size-paragraph:15px;
+\n$theme-color: #1FCF76;


### PR DESCRIPTION
## Summary
- register setting and account management pages
- implement `pages/user/setting.vue` for account options
- add profile editing page `personal.vue`
- create login password page `account.vue`
- create payment password setup page `payPwd.vue`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686325aa28e88331b368d2b6afb5b543